### PR TITLE
[Feat] 공용컴포넌트 Input 제작

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -52,6 +52,7 @@ export const WithInitialValueAndHint: Story = {
     const {
       register,
       formState: { errors },
+      watch,
     } = useForm({
       resolver: zodResolver(schema),
       mode: 'onChange',
@@ -67,7 +68,7 @@ export const WithInitialValueAndHint: Story = {
           placeholder='텍스트를 입력해 주세요'
           register={register('input')}
           error={errors.input}
-          initialValue='Valid text'
+          watchValue={watch('input')}
         />
         <p>{errors.input?.message}</p>
       </div>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
-import { ChangeEvent, InputHTMLAttributes, useEffect, useState } from 'react';
+import { ChangeEvent, InputHTMLAttributes, useState } from 'react';
 import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/cn';
 import z from 'zod';
@@ -26,7 +26,7 @@ interface InputProps extends VariantProps<typeof inputVariants> {
   autoComplete?: string;
   register?: UseFormRegisterReturn;
   error?: FieldError;
-  initialValue?: string;
+  watchValue?: string;
 }
 
 const inputVariants = cva(
@@ -52,12 +52,15 @@ const Input = ({
   autoComplete,
   register,
   error,
-  initialValue,
+  watchValue,
   size,
   ...rest
 }: InputProps) => {
-  const [isDirty, setIsDirty] = useState(false);
-
+  const [isDirty, setIsDirty] = useState(() => {
+    if (watchValue === undefined) return false;
+    if (watchValue.length === 0) return false;
+    return true;
+  });
   const errorState = isDirty ? !!error : 'undefined';
 
   const InputRegister = {
@@ -79,12 +82,6 @@ const Input = ({
   };
 
   const INPUT_STYLES = cn(inputVariants({ size }), ERROR_STATE_STYLES[`${errorState}`], className);
-
-  useEffect(() => {
-    console.log(initialValue);
-    if (!initialValue) return;
-    setIsDirty(true);
-  }, [initialValue]);
 
   return (
     <input


### PR DESCRIPTION
#  📜 작업 내용

공용컴포넌트 Input 제작

초기값이 있을 경우의 valid style을 적용하기 위해 watch 파라미터를 사용하였습니다(TextArea와 동일)

# 💡`InputSchema`

에러메시지는 사용하지 않지만 일단 작성해두었습니다.
```tsx
export const InputSchema = ({ minLength = 1, maxLength }: Input) => {
  return z
    .string()
    .min(1, '필수 입력 항목입니다') // min은 고정
    .min(minLength, `${minLength}자 이상으로 입력하세요`)
    .max(maxLength, `${maxLength}자 이하로 입력하세요`);
};
```

# 💡 Input.tsx
TextArea 컴포넌트와 동일한 관리방식으로 구현하였습니다.

size는 초기 설정용으로만 사용하시면 될듯 합니다.
기본값은 L 입니다.

# 💡 Storybook
Storybook에 아래와 같이 등록하였습니다.

<img width="766" height="701" alt="image" src="https://github.com/user-attachments/assets/575df34a-b6c0-4228-8dff-599aa9ab9732" />

