### PR TITLE
[Feat] Intersection Observer hook 추가

### DIFF
--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * 특정 요소가 뷰포트와 교차하는지 감지하는 커스텀 훅.
+ *
+ * @param {() => void} callback - 요소가 뷰포트에 나타날 때 실행될 콜백.
+ * @returns {React.RefObject<Element | null>} - 감지할 DOM 요소를 연결할 Ref 객체.
+ */
+export const useIntersectionObserver = (callback: () => void) => {
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) callback();
+      },
+      {
+        root: null, // 뷰포트를 기준으로 감지
+        threshold: 0.5, // 요소의 50%가 뷰포트에 보일 때 감지
+      },
+    );
+
+    const currentRef = observerRef.current;
+    if (currentRef) observer.observe(currentRef);
+
+    return () => {
+      if (currentRef) observer.unobserve(currentRef);
+    };
+  }, [callback]);
+
+  return observerRef;
+};


### PR DESCRIPTION
# 작업 내용
- Inersection Observer API 관련 훅 추가

## 세부 내용
- Inersection Observer API를 활용해 요소가 뷰포트에 들어오는 것을 감지할 수 있는 훅 추가
- 주로 무한 스크롤에 사용하기 위한 목적으로 구현
```js
/**
 * 특정 요소가 뷰포트와 교차하는지 감지하는 커스텀 훅.
 *
 * @param {() => void} callback - 요소가 뷰포트에 나타날 때 실행될 콜백.
 * @returns {React.RefObject<Element | null>} - 감지할 DOM 요소를 연결할 Ref 객체.
 */
export const useIntersectionObserver = (callback: () => void) => {
  // ...
}
```