### PR TITLE
[Fix] Textarea id, className props 추가, 기타 스타일 수정, 구조 수정

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -44,6 +44,16 @@ export const Default: Story = {
   },
 };
 
+// Basic TextArea width ClassName story
+export const DefaultWithClassName: Story = {
+  args: {
+    placeholder: `with className: 'min-h-32'`,
+    minLength: 1,
+    maxLength: 10,
+    className: 'min-h-32 w-full',
+  },
+};
+
 // TextArea with form validation
 export const WithValidation: Story = {
   render: (args) => {

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,8 +1,10 @@
-import { cn } from '@/lib/cn';
+import clsx from 'clsx';
 import { forwardRef, TextareaHTMLAttributes, useState } from 'react';
 import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  id?: string;
+  className?: string;
   placeholder?: string;
   register?: UseFormRegisterReturn;
   error?: FieldError;
@@ -11,7 +13,7 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 }
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ placeholder, register, error, maxLength, watchValue, ...rest }, ref) => {
+  ({ id, className, placeholder, register, error, maxLength, watchValue, ...rest }, ref) => {
     //watchValue가 없을때만 변경
     const [currentLength, setCurrentLength] = useState(0);
     const [isDirty, setIsDirty] = useState(() => {
@@ -54,30 +56,35 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         true: 'text-state-error',
       },
       border: {
-        undefined: 'border-gray-600',
+        undefined: 'border-gray-300',
         false: 'border-primary-orange-500',
         true: 'border-state-error',
       },
     };
 
-    const TEXTAREA_CONTAINER_STYLES = cn(
-      'flex w-full flex-col gap-2 rounded-lg border-1 border-gray-300 p-3 md:p-5',
-      ERROR_STATE_STYLES.border[`${errorState}`],
-      ERROR_STATE_STYLES.text[`${errorState}`],
-    );
-
-    const TEXTAREA_STYLES = cn(
+    const TEXTAREA_STYLES = clsx(
+      'w-full',
       'text-body2 md:text-body1 resize-none outline-0',
       'focus-within:placeholder:text-transparent',
+      'placeholder:text-gray-600',
+      'rounded-lg border-1 border-gray-300 p-3 md:p-5 pb-8 md:pb-10',
+      'field-sizing-content',
+      'block',
+      ERROR_STATE_STYLES.border[`${errorState}`],
     );
 
-    const LENGTH_INFO_STYLES = cn('text-body2 text-right');
+    const LENGTH_INFO_STYLES = clsx(
+      'absolute bottom-3 md:bottom-5 right-3 md:right-5',
+      'text-body2 text-right',
+      'text-gray-700',
+    );
 
     return (
-      <div className={TEXTAREA_CONTAINER_STYLES}>
+      <div className='relative w-full'>
         <textarea
           ref={ref}
-          className={TEXTAREA_STYLES}
+          id={id}
+          className={clsx(TEXTAREA_STYLES, className)}
           placeholder={placeholder}
           {...TextAreaRegister}
           {...rest}


### PR DESCRIPTION
# 📜 작업 내용


## 💡 Default style 수정
피그마 시안에 맞게 border 색상, text 색상을 수정하였습니다.

<img width="436" height="87" alt="image" src="https://github.com/user-attachments/assets/1f5e49c6-967d-48c8-9191-acbdb4db0eab" />
<img width="433" height="85" alt="image" src="https://github.com/user-attachments/assets/c62cf3ab-5d35-4249-9017-d94fb8263baf" />

<img width="434" height="85" alt="image" src="https://github.com/user-attachments/assets/f4669adc-f3ef-4334-b60d-4fc8db8f19c2" />


## 💡 구조 수정
TextArea 구조를 수정하였습니다.

TextArea에 직접 padding을 적용하였으며, 글자 수 표시 태그 (`<p/>`)는 absolute로 적용됩니다.

TextArea는 기본적으로 `w-full`이 적용되어있습니다.

```tsx
    return (
      <div className='relative w-full'>
        <textarea
          ref={ref}
          id={id}
          className={clsx(TEXTAREA_STYLES, className)}
          placeholder={placeholder}
          {...TextAreaRegister}
          {...rest}
        />
        <p className={LENGTH_INFO_STYLES}>{`${currentWatchLength}/${maxLength}`}</p>
      </div>
    );
```

## 💡 최소 높이, 최대 높이 지정
className에 'min-h' 등을 설정하여 최소 높이를 설정할 수 있습니다.

```tsx
<TextArea
  ...
  className='min-h-32'
  ...
/>
```

## 💡 참고 영상
![Animation](https://github.com/user-attachments/assets/0e86cfd4-34af-4738-8085-ed80e1f20a9f)
