### PR TITLE
[Style]: 모바일 뷰포트에서 ProductAddButton의 포지션 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
         <Providers>
           <Suspense fallback={<Loading />}>
             <Header />
-            <ProductAddButton className='fixed right-5 bottom-8 md:right-8 md:bottom-20 lg:right-[calc((100vw-980px)/2-72px))] lg:bottom-28' />
+            <ProductAddButton className='fixed right-5 bottom-[calc(17vw+32px)] md:right-8 md:bottom-20 lg:right-[calc((100vw-980px)/2-72px))] lg:bottom-28' />
             {children}
             <Footer />
           </Suspense>


### PR DESCRIPTION
# 작업 내용
- 모바일 환경에서 바텀 네비게이션이 추가됨에 따라, 기존 상품 추가 버튼의 포지셔닝을 변경했습니다.

## 프리뷰
<img width="480" height="747" alt="image" src="https://github.com/user-attachments/assets/bea5c07d-387e-40a5-8dd4-1bc0b8764646" />
